### PR TITLE
Prevent unnecessary copy of model traces

### DIFF
--- a/R/BCfit.R
+++ b/R/BCfit.R
@@ -2,22 +2,29 @@ BCfit <-
 function(y, X, covlist, R, z, mu, updateR, iters, thin = 1, burn = 0, priW = c(nrow(z) + 2 * ncol(z), 2 * ncol(z))) {
   
   spnames <- colnames(y)
-  y <- t(y)
-  nsp <- dim(y)[1]
-  n <- dim(y)[2]
-  iR <- solve(R)
-  e <- z - mu
+  y <- t(y)         # NOTE: y is transposed relative to the input!
+  nsp <- dim(y)[1]  # number of species
+  n <- dim(y)[2]    # number of sites
+  iR <- solve(R)    # Inverse correlation matrix
+  e <- z - mu       # component of z that can't be explained by mu
   
-  # set up trace arrays
   nsamp <- (iters - burn) %/% thin
-  trace_R <- array(NA, dim = c(nsamp, ((nsp * nsp - nsp) / 2))) #w /out redundant columns
-  trace_z <- array(NA, dim = c(nsamp, n, nsp))
-  trace_mu <- trace_z
-  trace_B <- NULL
+  
+  # Dave asks: Should mu be in the output as well? It wasn't before, but that 
+  #    may have been an oversight.
+  output <- list(
+    R = array(NA, dim = c(nsamp, ((nsp * nsp - nsp) / 2))), #w /out redundant columns 
+    B = NULL, 
+    z = array(NA, dim = c(nsamp, n, nsp)), 
+    burn = burn, 
+    thin = thin
+  )
+  trace_mu <- output$z
+  
   for (i in 1:nsp) {
     temp <- matrix(NA, nsamp, length(covlist[[i]]))
     colnames(temp) <- colnames(X)[covlist[[i]]]
-    trace_B[[spnames[i]]] <- temp
+    output$B[[spnames[i]]] <- temp
   }
   rm(temp)
   
@@ -28,8 +35,8 @@ function(y, X, covlist, R, z, mu, updateR, iters, thin = 1, burn = 0, priW = c(n
     }
   }
   
-  colnames(trace_R) <- nam[which(upper.tri(diag(nsp)))]
-  dimnames(trace_z)[[3]] <- spnames
+  colnames(output$R) <- nam[which(upper.tri(diag(nsp)))]
+  dimnames(output$z)[[3]] <- spnames
   dimnames(trace_mu)[[3]] <- spnames
   
   # start sampler
@@ -55,14 +62,14 @@ function(y, X, covlist, R, z, mu, updateR, iters, thin = 1, burn = 0, priW = c(n
     # record parameters    
     if (iter %% thin == 0 & iter > burn) {
       rec <- (iter - burn) %/% thin
-      trace_R[rec, ] <- R[upper.tri(R)]
-      trace_z[rec, , ] <- z
+      output$R[rec, ] <- R[upper.tri(R)]
+      output$z[rec, , ] <- z
       trace_mu[rec, , ] <- mu
       for (i in 1:nsp) {
-        trace_B[[i]][rec, ] <- mulis[[2]][[i]] 
+        output$B[[i]][rec, ] <- mulis[[2]][[i]] 
       }
     }
   }  # sampler
   
-  list(R = trace_R, B = trace_B, z = trace_z, burn = burn, thin = thin)
+  output
 }


### PR DESCRIPTION
I've been working with very large communities (350+ species) on a machine with 8 gigabytes of RAM. As a result, I've been having trouble fitting all of the trace objects into memory.

I noticed that the last line of BCfit copied all the trace objects to create the output list, which almost doubled the memory footprint for a brief period, leading R to abort the computation altogether if I kept more than a few hundred states of the MCMC chain after thinning.

I've avoided that duplication event by storing all the traces in the output list from the start.

The function's behavior should otherwise be unchanged (i.e. it should produce identical results).  The only other difference is that I added a few comments.
