### PR TITLE
add failing test for prediction

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^\.git$
 ^readme.md$
+.travis.yml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,5 +9,6 @@ Maintainer: Nick Golding
 Description: Bayesian multivariate binary (probit) regression
     models for analysis of ecological communities.
 License: GPL (>= 2)
-Imports: Rcpp (>= 0.11.6), abind, coda, mvtnorm
+Imports: Rcpp (>= 0.11.6), abind, coda, mvtnorm, progress
+Suggests: testthat
 LinkingTo: Rcpp, RcppArmadillo

--- a/R/bindSpeciesCoefficients.R
+++ b/R/bindSpeciesCoefficients.R
@@ -1,0 +1,13 @@
+# Helper function to bind the coefficient lists in B into an array.
+# Currently assumes that (i.e. no `covlist` was specified)
+bindSpeciesCoefficients <- function(object) {
+  pre.binding <- lapply(object$trace$B, function(x) {
+    dim(x) <- c(dim(x), 1)
+    x
+  })
+  
+  out <- do.call(abind::abind, pre.binding)
+  colnames(out) <- colnames(object$trace$B[[1]])
+  
+  out
+} 

--- a/R/logLik.R
+++ b/R/logLik.R
@@ -1,0 +1,45 @@
+logLik.bayescomm <- function(model, newdata, y, thin = 1){
+  if (missing(newdata)) {
+    # Already includes intercept column
+    x <- model$call$X
+  } else {
+    # Need to add intercept column
+    x <- cbind(1, newdata)
+  }
+  
+  B <- bindSpeciesCoefficients(model)
+  
+  lower = ifelse(y, 0, -Inf)
+  upper = ifelse(y, Inf, 0)
+  
+  indices = which(1:nrow(B) %% thin == 0)
+  
+  stopifnot(length(indices) > 0)
+
+  
+  pb <- progress::progress_bar$new(
+    format = ":current / :total  [:bar] :percent eta: :eta",
+    total = nrow(newdata) * length(indices), clear = FALSE, width = 60)
+  
+  sapply(
+    indices,
+    function(i){
+      mean.matrix <- x %*% B[i, , ]
+      R <- upper2cor(model$trace$R[i, ])
+      
+      sapply(
+        1:nrow(mean.matrix),
+        function(j){
+          pb$tick()
+          mvtnorm::pmvnorm(
+            lower = lower[j, ], 
+            upper = upper[j, ], 
+            mean = mean.matrix[j, ], 
+            corr = R
+          ) 
+        }
+      )
+    }
+  )
+}
+

--- a/R/logMeanExp.R
+++ b/R/logMeanExp.R
@@ -1,0 +1,4 @@
+logMeanExp = function(x){
+  biggest_value = max(x)
+  log(mean(exp(x - biggest_value))) + biggest_value
+}

--- a/R/predict.bayescomm.R
+++ b/R/predict.bayescomm.R
@@ -1,50 +1,26 @@
 predict.bayescomm <- function(object, newdata, ...) {
-  # Return an array of sample probabilities at new sites.  
-  # Rows are test sites; columns are species; slices are coefficient samples
- 
-  bindSpeciesCoefficients <- function(object) {
-    # Helper function to bind the coefficient lists in B into an array.
-    
-    pre.binding <- lapply(object$trace$B, function(x) {
-      dim(x) <- c(dim(x), 1)
-      x
-    })
-    
-    out <- do.call(abind, pre.binding)
-    colnames(out) <- colnames(object$trace$B[[1]])
-    
-    out
-  } 
+  # Return a matrix of marginal probabilitiesat new sites.  
   
-  
-  # Probably only works with the "full" model type and no `covlist` or
+  # Probably only works with the "full" model type and no `covlist`, `mu`, or
   # `condition` specified.
   
-  # Haven't played with any cases where mu isn't null
   if(!is.null(object$other$mu)){
     stop("predictions are not supported for non-null mu")
   }
   
   X <- cbind(intercept = 1, newdata)
   B <- bindSpeciesCoefficients(object)
-  R <- object$trace$R
-  n.species <- dim(B)[3]
   
-  predictions <- array(
-    NA, 
-    dim = c(nrow(X), dim(B)[3], nrow(B)), 
-    dimnames = list(row.names(X), dimnames(B)[[3]], NULL)
+  predictions <- matrix(
+    0, 
+    nrow = nrow(X), 
+    ncol = dim(B)[3], 
+    dimnames = list(row.names(X), dimnames(B)[[3]])
   )
   
-  # Fill in predictions slice by slice
+  
   for (i in 1:nrow(B)) {
-    Sigma <- matrix(0, nrow = n.species, ncol = n.species)
-    Sigma[upper.tri(Sigma)] <- R[i, ]  # Fill in upper triangle?
-    Sigma <- Sigma + t(Sigma)  # Fill in lower triangle?
-    diag(Sigma) <- 1  # Diagonal equals 1 in multivariate probit model
-    
-    Z <- rmvnorm(n = nrow(X), mean = rep(0, n.species), sigma = Sigma)
-    predictions[, , i] <- pnorm(X %*% B[i, , ] + Z)
+    predictions <- predictions + pnorm(X %*% B[i, , ]) / nrow(B)
   }
   
   predictions

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -1,0 +1,45 @@
+simulate.bayescomm <- function(object, nsim = NULL, seed = NULL, 
+                               replace = FALSE, ...){
+  
+  ## Begin code from `simulate.lm`:
+  if (!exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) 
+    runif(1)
+  if (is.null(seed)) 
+    RNGstate <- get(".Random.seed", envir = .GlobalEnv)
+  else {
+    R.seed <- get(".Random.seed", envir = .GlobalEnv)
+    set.seed(seed)
+    RNGstate <- structure(seed, kind = as.list(RNGkind()))
+    on.exit(assign(".Random.seed", R.seed, envir = .GlobalEnv))
+  }
+  ## End code from `simulate.lm`
+
+  if (is.null(nsim)) {
+    nsim <- nrow(object$trace$R)
+  }
+   
+  indices <- sample.int(nrow(object$trace$R), nsim, replace = replace)
+   
+  
+  if (!is.null(object$other$mu)){
+    stop("predictions are not supported for non-null mu")
+  }
+  
+  B <- bindSpeciesCoefficients(object)
+  X <- object$call$X
+  
+  val <- array(NA, dim = c(nsim, dim(object$call$Y)))
+  
+  for (i in indices) {
+    print(i)
+    R <- upper2cor(object$trace$R[i, ])
+    z <- X %*% B[i, , ] + mvtnorm::rmvnorm(nrow(X), sigma = R)
+    val[i, , ] <- ifelse(z > 0, 1, 0)
+  }
+
+  
+  ## Begin code from `simulate.lm`
+  attr(val, "seed") <- RNGstate
+  val
+  ## End code from `simulate.lm`
+}

--- a/R/upper2cor.R
+++ b/R/upper2cor.R
@@ -1,0 +1,15 @@
+upper2cor <- function(x){
+  # Turn a numeric vector with upper triangle values and
+  # complete the correlation matrix with this information
+  
+  # Dimension of the correlation matrix
+  # dim defined by solving length(x) == (dim * (dim - 1)) / 2
+  dim = (sqrt(8 * length(x) + 1) + 1) / 2
+  
+  out = matrix(0, dim, dim)  # Initialize
+  out[upper.tri(out)] = x    # Fill in upper triangle
+  out = out + t(out)         # Fill in lower triangle
+  diag(out) = 1              # Diagonal of correlation matrix is 1
+  
+  out
+}  

--- a/tests/testthat/test-BC.R
+++ b/tests/testthat/test-BC.R
@@ -60,16 +60,15 @@ test_that("true parameters are recovered", {
 
 
 test_that("true probabilities are recovered", {
-  p_array <- predict(m1, X[, -1])
-  
-  marginal_p <- apply(p_array, 2, rowMeans)
+  marginal_p <- predict(m1, X[, -1])
   
   # If the prediction code is correct, there shouldn't be any improvement after
   # accounting for the offset
-  prediction_lm <- lm(
-    c(qnorm(p)) ~ c(qnorm(marginal_p)) + offset(c(qnorm(marginal_p)))
+  prediction_glm <- glm(
+    c(Y) ~ c(qnorm(marginal_p)) + offset(c(qnorm(marginal_p))),
+    family = binomial(link = "probit")
   )
   
   # expect large p-values, fail to reject
-  expect_true(all(coef(summary(prediction_lm))[ , 4] > .01))
+  expect_true(all(coef(summary(prediction_glm))[ , 4] > .01))
 })

--- a/tests/testthat/test-BC.R
+++ b/tests/testthat/test-BC.R
@@ -1,5 +1,7 @@
 context("BC results match true values")
 
+# (Based on code from `example(BayesComm)`)
+
 set.seed(1)
 
 # create fake data
@@ -25,10 +27,21 @@ z <- mu + e  # true z
 
 Y <- ifelse(z > 0, 1, 0)  # true presence/absence
 
+# Fit a glm to Y with an offset equal to probit(p).
+# There should be no evidence that adding an intercept or a different slope
+# improves the relationship between Y and p
+p_glm <- glm(
+  c(Y) ~ c(qnorm(p)) + offset(c(qnorm(p))), 
+  family = binomial(link = "probit")
+)
+p_values <- summary(p_glm)$coefficients[ , 4]
+expect_true(all(p_values > .01)) # Expect large p-values
+
+
 
 
 # run BC (after removing intercept column from design matrix)
-m1 <- BC(Y, X[, -1], model = "full", its = 500)
+m1 <- BC(Y, X[, -1], model = "full", its = 1000)
 
 
 
@@ -43,4 +56,20 @@ test_that("true parameters are recovered", {
   expect_true(
     mean(R_diff)^2 / var(R[upper.tri(R)]) < .01
   )
+})
+
+
+test_that("true probabilities are recovered", {
+  p_array <- predict(m1, X[, -1])
+  
+  marginal_p <- apply(p_array, 2, rowMeans)
+  
+  # If the prediction code is correct, there shouldn't be any improvement after
+  # accounting for the offset
+  prediction_lm <- lm(
+    c(qnorm(p)) ~ c(qnorm(marginal_p)) + offset(c(qnorm(marginal_p)))
+  )
+  
+  # expect large p-values, fail to reject
+  expect_true(all(coef(summary(prediction_lm))[ , 4] > .01))
 })


### PR DESCRIPTION
Looks like the predict function I wrote doesn't do what it should.  Right now, the function effectively adds *two* Gaussians to the mean from `X %*% B`: one explicitly from the multivariate normal deviates and one implicitly with `pnorm`. Also, the distribution implicitly added by `pnorm` has diagonal covariance, which means that it's diluting the correlations in `R` and the effects of `B`.

This PR includes a failing test that diagnoses the problem.  Even though `B` and `R` are essentially correct, the predictions are systematically too close to 0.5.

I think we have a few options, but I wanted to talk them over with you before deciding on a fix.

Sorry about this...