### PR TITLE
make BCfit return a valid bayescomm object

### DIFF
--- a/R/BC.R
+++ b/R/BC.R
@@ -89,13 +89,8 @@ function(Y, X = NULL, model = 'null', covlist = NULL, condition = NULL, its = 10
   if (!updateR) W <- diag(nsp)
   R <- cov2cor(W)
   
-  reslis <- BCfit(Y, X, covlist, R, z, mu, updateR, its, ...)
-
-  res <- NULL
-  res$trace <- list(R = reslis$R, B = reslis$B, z = reslis$z)
-  res$call <- list(model = model, Y = Y, X = X, covlist = covlist, its = its,
-                   start = reslis$burn + 1, thin = reslis$thin)
-  res$other <- list(mu = reslis$mu)
-  class(res) <- "bayescomm"
-  res
+  out <- BCfit(Y, X, covlist, R, z, mu, updateR, its, ...)
+  out$call$model <- model
+  
+  out
 }


### PR DESCRIPTION
Mostly, this just moves the stuff that happens after `BCfit` inside that function so that it returns a valid "bayescomm" object with a `trace` list and so on.

The main benefit of this change is that methods that end in `bayescomm` will work properly on custom models from `BCfit`.

This PR also drops `.$other$mu`, which was always `NULL`. I think I added that without knowing what I was doing (I also deleted the comments where we talked about this issue).